### PR TITLE
Allow plugin to be used in any Grails 2.x app

### DIFF
--- a/AirbrakeGrailsPlugin.groovy
+++ b/AirbrakeGrailsPlugin.groovy
@@ -2,7 +2,7 @@ class AirbrakeGrailsPlugin {
     // the plugin version
     def version = "0.7"
     // the version or versions of Grails the plugin is designed for
-    def grailsVersion = "2.1 > *"
+    def grailsVersion = "2.0.0 > *"
     def pluginExcludes = [
             "grails-app/views/error.gsp",
             "test/**"


### PR DESCRIPTION
We don't require 2.1.x so lower the requirement to at least 2.0.0 
