### PR TITLE
Allow path configuration.

### DIFF
--- a/src/groovy/grails/plugins/airbrake/AirbrakeNotifier.groovy
+++ b/src/groovy/grails/plugins/airbrake/AirbrakeNotifier.groovy
@@ -18,8 +18,6 @@ class AirbrakeNotifier {
 
     final Configuration configuration
 
-	private String path = AIRBRAKE_PATH
-
     // mostly to make mocking easier in specs
     protected AirbrakeNotifier() {}
 
@@ -90,7 +88,7 @@ class AirbrakeNotifier {
     }
 
     private HttpURLConnection buildConnection() {
-        URL apiURL = new URL(configuration.scheme, configuration.host, configuration.port, path)
+        URL apiURL = new URL(configuration.scheme, configuration.host, configuration.port, configuration.path)
 
         HttpURLConnection conn = apiURL.openConnection()
         conn.setDoOutput(true)

--- a/src/groovy/grails/plugins/airbrake/Configuration.groovy
+++ b/src/groovy/grails/plugins/airbrake/Configuration.groovy
@@ -20,6 +20,7 @@ class Configuration {
     List<String> cgiDataFilteredKeys = []
     boolean secure = false
     boolean enabled = true
+    String path = AirbrakeNotifier.AIRBRAKE_PATH
     String host = AirbrakeNotifier.AIRBRAKE_HOST
     Integer port
     boolean includeEventsWithoutExceptions = false

--- a/test/unit/grails/plugins/airbrake/ConfigruationSpec.groovy
+++ b/test/unit/grails/plugins/airbrake/ConfigruationSpec.groovy
@@ -32,6 +32,25 @@ class ConfigruationSpec extends Specification {
         config.port == 1234
     }
 
+    def 'constructor assigns a path if none is specified'() {
+        when:
+        def config = new Configuration()
+
+        then:
+        config.path == AirbrakeNotifier.AIRBRAKE_PATH
+    }
+
+    def 'constructor uses supplied path'() {
+        given:
+        def suppliedPath = '/errbit/notifier_api/v2/notices'
+
+        when:
+        def config = new Configuration(path: suppliedPath)
+
+        then:
+        config.path == suppliedPath
+    }
+
     @Unroll
     def 'scheme'() {
         when:


### PR DESCRIPTION
I think that plugin should allow path configuration for advanced users.

I have Errbit deployed in-house to a non-root directory, e.g. localhost:8080/errbit. With this commit I can set up with:

```
host = 'localhost'
port = 8080
path = '/errbit/notifier_api/v2/notices'
```

Thanks for this plugin, works like a charm with Errbit.
